### PR TITLE
docs(blog): add post about Cloudflare Images $400 billing issue

### DIFF
--- a/src/content/blog/cloudflare-images-400.md
+++ b/src/content/blog/cloudflare-images-400.md
@@ -1,0 +1,24 @@
+---
+title: $400.69
+description: Cloudflare Images charged $400/mo instead of expected $110 due to confusing prepaid billing. Support ghosted for 8+ months...
+tags:
+  - cloudflare
+  - images
+  - billing
+author: Andras Bacsai
+authorTwitter: heyandras
+date: "2024-07-26T12:00:00.000Z"
+image: /assets/cloudflare-images-400.png
+category: development
+isNew: true
+---
+
+---
+
+[Original post](https://jpetazzo.github.io/2024/07/26/cloudflare-images-overcharge-billing/)
+
+Conclusion: No refund. Cloudflare support ghosted them for 8+ months. The overcharges eventually balance out, but the prepaid billing model is fundamentally broken.
+
+---
+
+__tldr: Cloudflare Images prepaid storage billing charged $400+/mo instead of the expected $110 — each capacity upgrade charges the full new amount upfront, but credits for the old capacity only appear on the next billing cycle. Cloudflare support was contacted in November 2023 and ghosted them for over 8 months.__


### PR DESCRIPTION
## Summary

- Add blog post documenting Cloudflare Images overcharging issue
- Post highlights the $400/mo overcharge due to confusing prepaid billing model
- References original post by jpetazzo and includes key findings
- Tags with cloudflare, images, and billing for discoverability

## Details

This post documents a notable case where Cloudflare Images charged $400.69/month instead of the expected $110 due to their prepaid billing model. When upgrading storage capacity, the full new amount is charged upfront while credits for the old capacity only appear on the next billing cycle, creating a timing gap.

The post also notes that Cloudflare support provided no assistance despite being contacted in November 2023, ghosting the user for 8+ months.

---

Closes #9